### PR TITLE
replace .ws urls and fix linting

### DIFF
--- a/packages/extension/src/EditorRichTextField/EditorRichTextField.stories.tsx
+++ b/packages/extension/src/EditorRichTextField/EditorRichTextField.stories.tsx
@@ -12,7 +12,7 @@ const imageValue = {
   id: "c2f2bed1-4ba7-4457-ae4d-85930e333b3a",
   name: "sap_cx_live_munich_home_1920x550_munich",
   endpoint: "willow",
-  defaultHost: "i1.adis.ws"
+  defaultHost: "cdn.media.amplience.net"
 };
 
 const mockSdk = new SDK();

--- a/packages/extension/src/ProseMirrorToolbar/ProseMirrorToolbar.stories.tsx
+++ b/packages/extension/src/ProseMirrorToolbar/ProseMirrorToolbar.stories.tsx
@@ -9,7 +9,7 @@ import ProseMirrorToolbar, { ToolbarElement } from "./ProseMirrorToolbar";
 import { ProseMirrorTool } from "@dc-extension-rich-text/common";
 // tslint:disable-next-line
 import FormatBold from "@material-ui/icons/FormatBold";
-import { computeToolbarState } from "./ProseMirrorToolbarState";
+import { computeToolbarState, ProseMirrorToolbarState } from "./ProseMirrorToolbarState";
 
 // tslint:disable-next-line
 const schema = require("prosemirror-schema-basic").schema;
@@ -53,7 +53,7 @@ const layout: ToolbarElement[] = [
 ];
 
 const Editor: React.SFC<{}> = (props: any) => {
-  const [toolbarState, setToolbarState] = React.useState();
+  const [toolbarState, setToolbarState] = React.useState<ProseMirrorToolbarState>();
 
   const handleUpdateState = React.useCallback(
     (state: any, view: any) => {

--- a/packages/extension/src/RichTextEditor/RichTextEditor.tsx
+++ b/packages/extension/src/RichTextEditor/RichTextEditor.tsx
@@ -15,7 +15,7 @@ import ProseMirrorToolbar, {
 } from "../ProseMirrorToolbar/ProseMirrorToolbar";
 import DefaultToolbar from "./DefaultToolbar";
 
-import { computeToolbarState } from "../ProseMirrorToolbar/ProseMirrorToolbarState";
+import { computeToolbarState, ProseMirrorToolbarState } from "../ProseMirrorToolbar/ProseMirrorToolbarState";
 import { RichTextDialogsContext } from "../RichTextDialogs";
 
 const styles = {
@@ -157,7 +157,7 @@ const RichTextEditor: React.SFC<RichTextEditorProps> = (
     [languageConfiguration, setProseMirrorDocument, setRawValue]
   );
 
-  const [toolbarState, setToolbarState] = React.useState();
+  const [toolbarState, setToolbarState] = React.useState<ProseMirrorToolbarState>();
   const toolbarLayout = toolbarLayoutProp || DefaultToolbar;
 
   const handleEditorUpdateState = React.useCallback(

--- a/packages/prosemirror-dynamic-content/src/DcImageLink/DcImageLinkNode.stories.ts
+++ b/packages/prosemirror-dynamic-content/src/DcImageLink/DcImageLinkNode.stories.ts
@@ -32,7 +32,7 @@ storiesOf("DcImageLinkNode", module).add("Editor", () => {
             id: "2bfd10cd-d3df-4d57-b6ae-40609a357033",
             name: "How-To-Pack-Your-Suitcase",
             endpoint: "willow",
-            defaultHost: "i1.adis.ws",
+            defaultHost: "cdn.media.amplience.net",
             "@id":
               "http://image.cms.amplience.com/2bfd10cd-d3df-4d57-b6ae-40609a357033",
             mediaType: "image"
@@ -73,7 +73,7 @@ storiesOf("DcImageLinkNode", module).add("Editor", () => {
           "dc-image-link": (node: any, view: any, getPos: any) =>
             new DcImageLinkView(node, view, getPos, {
               dynamicContent: {
-                stagingEnvironment: "i1.adis.ws"
+                stagingEnvironment: "cdn.media.amplience.net"
               }
             })
         }


### PR DESCRIPTION
In this PR `i1.adis.ws` url replaced with `cdn.media.amplience.net` in `.stories.js` files.
Also add types of arguments in SetStateAction for successful `yarn run storybook` command run with node `v13`