### PR TITLE
docs: Updated inline styles in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ This extension is designed to replace the built in rich text editor with additio
   * Block quotes
   * Code snippets
   * Horizontal rules
-  * Experimental: Inline styles
+  * Inline styles
 * JSON output
   * Markdown Blocks
   * Content Blocks
@@ -342,17 +342,23 @@ When using multiple of these properties, use them on the same object:
 }
 ```
 
-### Experimental: Inline Styles
+### Inline Styles
 
-Inline styles is an experimental feature which lets you provide a list of CSS class names that users can apply to text.
+Inline styles is a feature which lets you provide a list of CSS class names that users can apply to text.
 
 ![Content Block](media/inline-styles.png)
 
 To enable this feature:
 
-1. Remove the feature from the blacklist.
+1. Create CSS rules for your inline styles within `params`:
 
-This feature is blacklisted by default, you can enable it by passing in an empty blacklist.
+```json
+{
+    "styles": ".was-price { color: red; }"
+}
+```
+
+2. Within `params.tools`, remove the feature from the blacklist. This feature is blacklisted by default, you can enable it by passing in an empty blacklist.
 
 ```json
 {
@@ -362,27 +368,21 @@ This feature is blacklisted by default, you can enable it by passing in an empty
 }
 ```
 
-2. Provide custom CSS:
+3. Within `params.tools`, provide settings for each inline style you wish to use.
 
 ```json
 {
-    "styles": ".was-price { color: red; }"
-}
-```
-
-3. Provide settings for the tool
-
-```json
-{
-    "inline_styles": {
-        "classNames": [
-            { "className": "was-price", "label": "Was Price" }
-        ]
+    "tools": {
+        "inline_styles": {
+            "classNames": [
+                { "className": "was-price", "label": "Was Price" }
+            ]
+        }
     }
 }
 ```
 
-4. Add the classes to the toolbar
+4. Within `params`, add your inline styles to the toolbar.
 
 ```json
 {
@@ -402,7 +402,6 @@ This feature is blacklisted by default, you can enable it by passing in an empty
         ]
     }
 }
-
 ```
 
 ## How to run locally

--- a/README.md
+++ b/README.md
@@ -362,9 +362,7 @@ To enable this feature:
 
 ```json
 {
-    "tools": {
-        "blacklist": []
-    }
+    "blacklist": []
 }
 ```
 
@@ -372,12 +370,10 @@ To enable this feature:
 
 ```json
 {
-    "tools": {
-        "inline_styles": {
-            "classNames": [
-                { "className": "was-price", "label": "Was Price" }
-            ]
-        }
+    "inline_styles": {
+        "classNames": [
+            { "className": "was-price", "label": "Was Price" }
+        ]
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -342,9 +342,9 @@ When using multiple of these properties, use them on the same object:
 }
 ```
 
-### Inline Styles
+### Experimental: Inline Styles
 
-Inline styles is a feature which lets you provide a list of CSS class names that users can apply to text.
+Inline styles is an experimental feature which lets you provide a list of CSS class names that users can apply to text.
 
 ![Content Block](media/inline-styles.png)
 
@@ -362,7 +362,7 @@ To enable this feature:
 
 ```json
 {
-    "blacklist": []
+  "blacklist": []
 }
 ```
 
@@ -370,33 +370,79 @@ To enable this feature:
 
 ```json
 {
-    "inline_styles": {
-        "classNames": [
-            { "className": "was-price", "label": "Was Price" }
-        ]
-    }
+  "inline_styles": {
+    "classNames": [
+      {
+        "className": "was-price",
+        "label": "Was Price"
+      }
+    ]
+  }
 }
 ```
 
-4. Within `params`, add your inline styles to the toolbar.
+4. Within `params`, add your inline styles to the toolbar. Each style must be defined in the `toolNames` array, prefixed with `inline_styles_classname_` and ending with each style's `className` property.
 
 ```json
 {
-    "toolbar": {
-        "layout": [
+  "toolbar": {
+    "layout": [
+      {
+        "type": "dropdown",
+        "label": "Styles",
+        "toolNames": [
+          "inline_styles_className_was-price"
+        ]
+      },
+      {
+        "type": "button",
+        "toolName": "clear_formatting"
+      }
+    ]
+  }
+}
+```
+
+#### Example
+
+An example of configured parameters for inline styles combining each the previous steps can be seen below:
+
+```json
+{
+  "rich-text": {
+    "type": "string",
+    "ui:extension": {
+      "url": "https://rich-text.extensions.content.amplience.net",
+      "params": {
+        "tools": {
+          "blacklist": [],
+          "inline_styles": {
+            "classNames": [
+              {
+                "className": "was-price",
+                "label": "Was Price"
+              }
+            ]
+          }
+        },
+        "toolbar": {
+          "layout": [
             {
-                "type": "dropdown",
-                "label": "Styles",
-                "toolNames": [
-                    "inline_styles_className_was-price"
-                ]
+              "type": "dropdown",
+              "label": "Styles",
+              "toolNames": [
+                "inline_styles_className_was-price"
+              ]
             },
             {
-                "type": "button",
-                "toolName": "clear_formatting"
+              "type": "button",
+              "toolName": "clear_formatting"
             }
-        ]
+          ]
+        }
+      }
     }
+  }
 }
 ```
 


### PR DESCRIPTION
Updated inline styles in README:
- Clarified the position of each property within `params`
- Provided an example of combined parameters