### PR TITLE
feat: support installation params

### DIFF
--- a/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
+++ b/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
@@ -91,7 +91,7 @@ const EditorRichTextField: React.SFC<EditorRichTextFieldProps> = (
   const { sdk } = React.useContext(SdkContext);
   const { dialogs } = React.useContext(RichTextDialogsContext);
 
-  params = sdk ? { ...sdk.params.instance, ...sdk.params.installation } : params;
+  params = sdk ? { ...sdk.params.installation, ...sdk.params.instance } : params;
 
   const toolOptions = React.useMemo<DynamicContentToolOptions>(() => {
     const settings = {

--- a/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
+++ b/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
@@ -83,7 +83,7 @@ const EditorRichTextField: React.SFC<EditorRichTextFieldProps> = (
 ) => {
   const { schema, value: valueProp, onChange, classes } = props;
 
-  const params: EditorRichTextFieldParams =
+  let params: EditorRichTextFieldParams =
     schema && schema["ui:extension"] && schema["ui:extension"].params
       ? schema["ui:extension"].params
       : {};
@@ -91,18 +91,18 @@ const EditorRichTextField: React.SFC<EditorRichTextFieldProps> = (
   const { sdk } = React.useContext(SdkContext);
   const { dialogs } = React.useContext(RichTextDialogsContext);
 
-  const toolOptions = React.useMemo<DynamicContentToolOptions>(() => {
-    const sdkParams = sdk ? { ...sdk.params.instance, ...sdk.params.installation } : params;
+  params = sdk ? { ...sdk.params.instance, ...sdk.params.installation } : params;
 
+  const toolOptions = React.useMemo<DynamicContentToolOptions>(() => {
     const settings = {
-      useClasses: sdkParams.useClasses,
-      classOverride: sdkParams.classOverride,
+      useClasses: params.useClasses,
+      classOverride: params.classOverride,
 
       dialogs,
       dynamicContent: {
         stagingEnvironment: sdk ? sdk.stagingEnvironment : undefined
       },
-      tools: sdkParams.tools
+      tools: params.tools
     };
 
     if (settings.tools && !settings.tools.blacklist) {

--- a/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
+++ b/packages/extension/src/EditorRichTextField/EditorRichTextField.tsx
@@ -92,15 +92,17 @@ const EditorRichTextField: React.SFC<EditorRichTextFieldProps> = (
   const { dialogs } = React.useContext(RichTextDialogsContext);
 
   const toolOptions = React.useMemo<DynamicContentToolOptions>(() => {
+    const sdkParams = sdk ? { ...sdk.params.instance, ...sdk.params.installation } : params;
+
     const settings = {
-      useClasses: params.useClasses,
-      classOverride: params.classOverride,
+      useClasses: sdkParams.useClasses,
+      classOverride: sdkParams.classOverride,
 
       dialogs,
       dynamicContent: {
         stagingEnvironment: sdk ? sdk.stagingEnvironment : undefined
       },
-      tools: params.tools
+      tools: sdkParams.tools
     };
 
     if (settings.tools && !settings.tools.blacklist) {


### PR DESCRIPTION
This PR allows the rich text extension to load parameters from the installation params. When there is a conflict, the instance parameters will be preferred.