### PR TITLE
Docs: Added a Second CSS Class in Experimental: Inline Styles Section

### DIFF
--- a/README.md
+++ b/README.md
@@ -575,7 +575,7 @@ To enable this feature:
 
 ```json
 {
-  "styles": ".was-price { color: red; }"
+  "styles": ".was-price { color: red; } .promotion { color: green; }"
 }
 ```
 


### PR DESCRIPTION
Updated the **Experimental: Inline Styles** section to include a second CSS style, ensuring clarity that a space is required between styles. This update aligns with the accompanying image, which illustrates the .was-price and .promotion styles.